### PR TITLE
feat: add types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,19 @@
+/// <reference types="node" />
+export namespace ProcessOnSpawn {
+  export interface SpawnOptions {
+    env: NodeJS.ProcessEnv
+    cwd: string
+    execPath: string
+    args: ReadonlyArray<string>
+    detached: boolean
+    uid?: number
+    gid?: number
+    windowsVerbatimArguments: boolean
+    windowsHide: boolean
+  }
+  export type Handler = (opts: SpawnOptions) => any
+}
+export function addListener(fn: ProcessOnSpawn.Handler): void
+export function prependListener(fn: ProcessOnSpawn.Handler): void
+export function removeListener(fn: ProcessOnSpawn.Handler): void
+export function removeAllListeners(): void

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"fromentries": "^1.2.0"
 	},
 	"devDependencies": {
+		"@types/node": "^20.1.3",
 		"c8": "^7.0.0",
 		"if-ver": "^1.1.0",
 		"standard-version": "^8.0.0",


### PR DESCRIPTION
This makes it possible to use process-on-spawn in a typescript context more easily.

An alternative approach would be to port the code to typescript and build it that way.  Happy to send a PR do that instead, or fork or take over the module if you don't want to be bothered.

Thanks!